### PR TITLE
fix scratchy noise due to ADPCM nibbles being swapped (#7)

### DIFF
--- a/tecmo/src/snd/PCMCounter.scala
+++ b/tecmo/src/snd/PCMCounter.scala
@@ -92,7 +92,7 @@ class PCMCounter extends Module {
   }
 
   // Outputs
-  io.dout := RegNext(Mux(addrReg(0), io.rom.dout(7, 4), io.rom.dout(3, 0)), io.rom.valid)
+  io.dout := RegNext(Mux(!addrReg(0), io.rom.dout(7, 4), io.rom.dout(3, 0)), io.rom.valid)
   io.rom.rd := busyReg
   io.rom.addr := addrReg(16, 1)
 

--- a/tecmo/test/src/snd/PCMCounterTest.scala
+++ b/tecmo/test/src/snd/PCMCounterTest.scala
@@ -95,10 +95,10 @@ class PCMCounterTest extends AnyFlatSpec with ChiselScalatestTester with Matcher
       dut.io.rom.dout.poke(0xab)
       dut.io.rom.valid.poke(true)
       dut.clock.step()
-      dut.io.dout.expect(0xb)
+      dut.io.dout.expect(0xa)
       stepCounter(dut)
       dut.clock.step()
-      dut.io.dout.expect(0xa)
+      dut.io.dout.expect(0xb)
     }
   }
 }


### PR DESCRIPTION
It turns out the ADPCM nibbles were swapped!

Before:
https://github.com/user-attachments/assets/d241164b-f1b1-463a-82bd-251e42745f7a

After: 
https://github.com/user-attachments/assets/db67e849-7fb3-4801-8913-0ea72e0d513b

I updated the `PCMCounter` tests to pass.

Here is the same fix [PR applied over on MiSTer Tecmo](https://github.com/MiSTer-devel/Arcade-Tecmo_MiSTer/pull/18)

Thanks for the great work,
Gordon.